### PR TITLE
Completion Request should return CompletionList

### DIFF
--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -17,7 +17,8 @@ use LanguageServer\Protocol\{
     FormattingOptions,
     TextEdit,
     CompletionItem,
-    CompletionItemKind
+    CompletionItemKind,
+    CompletionList
 };
 use LanguageServer\Server\Completion\PHPKeywords;
 
@@ -166,7 +167,9 @@ class TextDocument
     
     public function completion(TextDocumentIdentifier $textDocument, Position $position)
     {
-        $items = [];
+        $list = new CompletionList();
+        $list->isIncomplete = false;
+        $list->items = [];
         $keywords = new PHPKeywords();
         foreach ($keywords->getKeywords() as $keyword){
             $item = new CompletionItem();
@@ -174,9 +177,9 @@ class TextDocument
             $item->kind = CompletionItemKind::KEYWORD;
             $item->insertText = $keyword->getInsertText();
             $item->detail = "PHP Language Server";
-            $items[] = $item;
+            $list->items[] = $item;
         }
-        return $items;
+        return $list;
     }
     
 }


### PR DESCRIPTION
As discussed in https://github.com/Microsoft/language-server-protocol/issues/39 statically typed languages like Java do not support mixed return types, which in the case of Completion Request is `CompletionItem[] | CompletionList`.

Thus Typefox - the Java client of the language server protocol - accepts only `CompletionList`, which contains `CompletionItem[]`.

In order to work with Eclipse Che and other IDEs using the Typefox client, the Completion Request handler in the PHP language server should return `CompletionList` instead of `CompletionItems[]`.
